### PR TITLE
support skipping second MFA

### DIFF
--- a/config-loader.go
+++ b/config-loader.go
@@ -7,6 +7,7 @@ import "fmt"
 import "errors"
 
 var badCfgErr = errors.New("Bad configuration file!")
+var awsProfileNotFound = errors.New("AWS profile not found!")
 
 var debugCfg = debug.Debug("oktad:config")
 
@@ -108,7 +109,8 @@ func loadAwsCfg() (*ini.File, error) {
 }
 
 // reads your AWS config file to load the role ARN
-// for a specific profile; returns the ARN and an error if any
+// for a specific profile; returns the ARN, whether we found your profile,
+// and an error if any
 func readAwsProfile(name string) (AwsConfig, error) {
 	var cfg AwsConfig
 	asec, err := loadAwsCfg()
@@ -120,7 +122,7 @@ func readAwsProfile(name string) (AwsConfig, error) {
 	s, err := asec.GetSection(name)
 	if err != nil {
 		debugCfg("aws profile read err, %s", err)
-		return cfg, err
+		return cfg, awsProfileNotFound
 	}
 
 	if !s.HasKey("role_arn") {

--- a/creds.go
+++ b/creds.go
@@ -12,9 +12,10 @@ import "github.com/tj/go-debug"
 import "github.com/aws/aws-sdk-go/aws/credentials"
 
 var debugCredStore = debug.Debug("oktad:credStore")
-
 var credsNotFound = errors.New("credentials not found!")
 var credsExpired = errors.New("credentials expired!")
+
+const BASE_PROFILE_CREDS = "__oktad_base_credentials"
 
 type CredStore map[string]AwsCreds
 type AwsCreds struct {
@@ -141,7 +142,11 @@ func loadCreds(profile string) (*credentials.Credentials, error) {
 
 	creds, ok := allCreds[profile]
 	if !ok {
-		return nil, credsNotFound
+		creds, ok = allCreds[BASE_PROFILE_CREDS]
+		if !ok {
+			return nil, credsNotFound
+		}
+
 	}
 
 	if time.Now().UnixNano() >= creds.Expiration.UnixNano() {


### PR DESCRIPTION
This utility is handy for AssumeRole-ing to run commands in a sub-account setup but could also be handy for running commands on the base account as well. This PR adds support for omitting a profile name, which is to say: if `oktad` fails to find the AWS profile you put in the arguments you type, it will, for now, assume you only want to AssumeRole into the account authorized through your Okta SAML assertion. 

Eventually this program's usage should more closely resemble [aws-vault](https://github.com/99designs/aws-vault), because forcing people to type `oktad exec` before their command could help remove some option parsing ambiguity, and the other options `aws-vault` provides would be handy, like its ability to manage different profiles—in some cases, we're finding that we need people to use two different Okta appUrls for different things, and there's no solution for that now other than to change `~/.okta-aws/config` when necessary.
