### PR TITLE
Handle push type factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ First, create an `~/.okta-aws/config` file with your Ookta base URL and app URL,
 [okta]
 baseUrl=https://mycompany.okta.com/
 appUrl=https://mycompany.okta.com/app/YOUR_APP/OKTA_MAGIC/sso/saml
+
+tokenFactor=push (optional, uses Okta Verify)
 ```
 
 Third, set up an AWS CLI config file. You need to create `~/.aws/config` and fill it with a profile containing the ARN for a role you ultimately want to get temporary credentials for. This file might look like the following:

--- a/config-loader.go
+++ b/config-loader.go
@@ -12,8 +12,9 @@ var awsProfileNotFound = errors.New("AWS profile not found!")
 var debugCfg = debug.Debug("oktad:config")
 
 type OktaConfig struct {
-	BaseURL string
-	AppURL  string
+	BaseURL     string
+	AppURL      string
+	TokenFactor string
 }
 
 // this is what we care about
@@ -55,6 +56,14 @@ func parseConfig(fname string) (OktaConfig, error) {
 
 	cfg.BaseURL = bu.String()
 	cfg.AppURL = au.String()
+
+	if osec.HasKey("tokenFactor") {
+		tokenFactor, err := osec.GetKey("tokenFactor")
+		if err != nil {
+			return cfg, err
+		}
+		cfg.TokenFactor = tokenFactor.String()
+	}
 
 	return cfg, nil
 }

--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func getSessionFromLogin(oktaCfg *OktaConfig) (string, error) {
 		return "", errors.New("MFA required to use this tool")
 	}
 
-	factor, err := extractTokenFactor(ores)
+	factor, err := extractTokenFactor(oktaCfg, ores)
 
 	if err != nil {
 		fmt.Println("Error processing okta response!")

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ import "github.com/havoc-io/go-keytar"
 const VERSION = "0.7.0"
 const SESSION_COOKIE = "__oktad_session_cookie"
 
+var unknownMfaType = errors.New("unknown MFA type")
+
 func main() {
 	var opts struct {
 		ConfigFile          string `short:"c" long:"config" description:"Path to config file"`
@@ -226,7 +228,7 @@ func challengeMfa(ores *OktaLoginResponse, factor *OktaMfaFactor) (string, error
 
 	fmt.Println("Unsupported MFA type:", factor.FactorType)
 	fmt.Println("Supported types: TOTP and Okta Verify Push")
-	return "", errors.New("unknown MFA type")
+	return "", unknownMfaType
 }
 
 func challengePushMfa(ores *OktaLoginResponse, factor *OktaMfaFactor) (string, error) {

--- a/main.go
+++ b/main.go
@@ -224,7 +224,8 @@ func challengeMfa(ores *OktaLoginResponse, factor *OktaMfaFactor) (string, error
 		return sessionToken, err
 	}
 
-	fmt.Println("Unknown MFA type:", factor.FactorType)
+	fmt.Println("Unsupported MFA type:", factor.FactorType)
+	fmt.Println("Supported types: TOTP and Okta Verify Push")
 	return "", errors.New("unknown MFA type")
 }
 

--- a/okta.go
+++ b/okta.go
@@ -11,8 +11,8 @@ import "encoding/base64"
 import "github.com/tj/go-debug"
 import "github.com/PuerkitoBio/goquery"
 import (
-	"net/http"
 	"github.com/havoc-io/go-keytar"
+	"net/http"
 )
 
 var noMfaError = errors.New("MFA required to use this tool")
@@ -20,6 +20,8 @@ var wrongMfaError = errors.New("No valid mfa congfigured for your account!")
 var loginFailedError = errors.New("login failed")
 
 var debugOkta = debug.Debug("oktad:okta")
+
+var defaultTokenFactor = "token:software:totp"
 
 type OktaLoginRequest struct {
 	Username string `json:"username"`
@@ -145,42 +147,40 @@ func makeRequestBody(t interface{}) io.Reader {
 }
 
 // pulls the factor we should use out of the response
-func extractTokenFactor(ores *OktaLoginResponse) (*OktaMfaFactor, error) {
+func extractTokenFactor(oktaCfg *OktaConfig, ores *OktaLoginResponse) (*OktaMfaFactor, error) {
 	factors := ores.Embedded.Factors
 	if len(factors) == 0 {
 		return nil, errors.New("MFA factors not present in response")
 	}
 
+	if oktaCfg.TokenFactor != "" && oktaCfg.TokenFactor != defaultTokenFactor {
+		tokenFactor, err := findTokenFactor(factors, oktaCfg.TokenFactor)
+
+		if err == nil {
+			return tokenFactor, err
+		}
+		debugOkta("could not find preferred token factor", oktaCfg.TokenFactor)
+	}
+
+	tokenFactor, err := findTokenFactor(factors, defaultTokenFactor)
+	return tokenFactor, err
+}
+
+func findTokenFactor(factors []OktaMfaFactor, factorType string) (*OktaMfaFactor, error) {
 	var tokenFactor *OktaMfaFactor
 	for _, factor := range factors {
-		// need to assert that this is a map
-		// since I don't know the structure enough
-		// to make a struct for it
-		if factor.FactorType == "push" {
-			debugOkta("push found!")
+		if factor.FactorType == factorType {
+			debugOkta("token factor type found!", factorType)
 			tokenFactor = &factor
 			break
 		}
 	}
 
-    if tokenFactor == nil {
-        for _, factor := range factors {
-            // need to assert that this is a map
-            // since I don't know the structure enough
-            // to make a struct for it
-            if factor.FactorType == "token:software:totp" {
-                debugOkta("software totp token found!")
-                tokenFactor = &factor
-                break
-            }
-        }
-    }
-
-	if tokenFactor.Id == "" {
-		return nil, wrongMfaError
+	if tokenFactor != nil && tokenFactor.Id != "" {
+		return tokenFactor, nil
 	}
 
-	return tokenFactor, nil
+	return nil, wrongMfaError
 }
 
 // do that mfa stuff


### PR DESCRIPTION
Adds support for Okta Verify's Push based 2FA.

This still hits the same endpoint as the original, just doesn't actually send any code.  After you've approved the request on your phone, the endpoint will return success.