### PR TITLE
Allow Role selection

### DIFF
--- a/okta.go
+++ b/okta.go
@@ -55,9 +55,9 @@ type OktaSamlResponse struct {
 	raw        string
 	XMLname    xml.Name `xml:"Response"`
 	Attributes []struct {
-		Name       string `xml:",attr"`
-		NameFormat string `xml:",attr"`
-		Value      string `xml:"AttributeValue"`
+		Name       string   `xml:",attr"`
+		NameFormat string   `xml:",attr"`
+		Value      []string `xml:"AttributeValue"`
 	} `xml:"Assertion>AttributeStatement>Attribute"`
 }
 


### PR DESCRIPTION
When there are multiple values to <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">, instead of blindly taking the first one, prompt the user for the one she wants.

This is needed if you have multiple targets and a 1:1 mapping between a Cross-Account role and a target role.