### PR TITLE
Cross account config

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -32,13 +32,19 @@ func assumeFirstRole(acfg AwsConfig, saml *OktaSamlResponse) (*credentials.Crede
 
 	var arns *SamlProviderArns
 	var found bool = false
+	var err error
 
 	for _, a := range saml.Attributes {
 		if a.Name == "https://aws.amazon.com/SAML/Attributes/Role" {
-			crossAccountArn, err := selectCrossAccount(a.Value)
+			var crossAccountArn string
+			if acfg.CrossAcctArn != "" {
+				crossAccountArn = acfg.CrossAcctArn
+			} else {
+				crossAccountArn, err = selectCrossAccount(a.Value)
 
-			if err != nil {
-				return nil, emptyExpire, err
+				if err != nil {
+					return nil, emptyExpire, err
+				}
 			}
 
 			for _, v := range a.Value {

--- a/okta.go
+++ b/okta.go
@@ -55,9 +55,9 @@ type OktaSamlResponse struct {
 	raw        string
 	XMLname    xml.Name `xml:"Response"`
 	Attributes []struct {
-		Name       string `xml:",attr"`
-		NameFormat string `xml:",attr"`
-		Value      string `xml:"AttributeValue"`
+		Name       string   `xml:",attr"`
+		NameFormat string   `xml:",attr"`
+		Value      []string `xml:"AttributeValue"`
 	} `xml:"Assertion>AttributeStatement>Attribute"`
 }
 


### PR DESCRIPTION
 Allow automatic role selection for cross-account role by following the `source_profile` "trail" in `.aws/config`

This would address https://github.com/RedVentures/oktad/pull/20#issuecomment-339164077

Before adding documentation for this feature, please let me know if you think this use of `source_profile` is legit or if I'm abusing it (I couldn't find any documentation anywhere explaining how it's meant to be used).